### PR TITLE
fix missing headers

### DIFF
--- a/src/gi/src/bvh_embree.cpp
+++ b/src/gi/src/bvh_embree.cpp
@@ -25,6 +25,7 @@
 #include <assert.h>
 #include <atomic>
 #include <iterator>
+#include <cmath>
 
 using namespace gi;
 using namespace gi::bvh;

--- a/src/imgio/src/mmap.c
+++ b/src/imgio/src/mmap.c
@@ -22,6 +22,7 @@
 #include <assert.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #if defined (_WIN32)
 #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
gatling/src/gi/src/bvh_embree.cpp:146:28: error: ‘fminf’ was not declared in this scope

gatling/src/imgio/src/mmap.c:342:8: error: unknown type name ‘uint32_t’
