### PR TITLE
hdGatling/gi: fix GPU memory leaks during animation rendering

### DIFF
--- a/src/hdGatling/mesh.cpp
+++ b/src/hdGatling/mesh.cpp
@@ -482,6 +482,8 @@ void HdGatlingMesh::Sync(HdSceneDelegate* sceneDelegate,
     (*dirtyBits & HdChangeTracker::DirtyPoints) |
     (*dirtyBits & HdChangeTracker::DirtyNormals) |
     (*dirtyBits & HdChangeTracker::DirtyPrimvar) |
+    (*dirtyBits & HdChangeTracker::DirtyInstancer) |
+    (*dirtyBits & HdChangeTracker::DirtyTransform) |
     (*dirtyBits & HdChangeTracker::DirtyTopology);
 
   if (updateGeometry)


### PR DESCRIPTION
When loading a USD file with animations, a memory leak was discovered. After investigation, it was found that the buffer created in _giCreateBvh() was not being released after use. The issue was traced back to the 'updateGeometry' check, where a specific flag was missing.